### PR TITLE
log-all-requests

### DIFF
--- a/src/api_bot/api_bot.py
+++ b/src/api_bot/api_bot.py
@@ -72,8 +72,9 @@ class ApiBot:
         if content_type is not None and "json" in content_type:
             logging.info(f"{response.json()}")
             self.response_data.extend(response.json())
-            log_data = ResponseLog(response)
-            self.response_log.append(log_data.to_json())
+
+        log_data = ResponseLog(response)
+        self.response_log.append(log_data.to_json())
 
     @staticmethod
     def show_progress(count: int, total: int):

--- a/src/api_bot/response_log.py
+++ b/src/api_bot/response_log.py
@@ -14,6 +14,8 @@ class ResponseLog:
             "status": self.response.status_code,
             "content-type": self.response.headers.get("content-type"),
             "content-length": self.response.headers.get("content-length"),
-            "data": self.response.json(),
+            "data": self.response.json()
+            if len(self.response.content) > 0 and self.response.content is not None
+            else None,
         }
         return data


### PR DESCRIPTION
Always log request execution, even if no content or content.